### PR TITLE
invoker version off

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@ SOFTWARE.
     <checkstyle.version>8.15</checkstyle.version>
     <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
     <sa-tan.version>0.1.5</sa-tan.version>
-    <maven-invoker-plugin.version>3.5.1</maven-invoker-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     <mockito-core.version>5.3.1</mockito-core.version>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `maven-invoker-plugin` version from `pom.xml`.

### Detailed summary
- Removed `maven-invoker-plugin.version` from `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->