### PR TITLE
jtcop rule assertion supressed on JUnit assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ SOFTWARE.
     <xembly.version>0.28.1</xembly.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     <maven-verifier-plugin.version>1.1</maven-verifier-plugin.version>
-    <jtcop.version>0.1.14</jtcop.version>
+    <jtcop.version>0.1.16</jtcop.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <checkstyle.version>10.12.0</checkstyle.version>
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>

--- a/src/test/java/io/github/eocqrs/xfake/LoggedTest.java
+++ b/src/test/java/io/github/eocqrs/xfake/LoggedTest.java
@@ -39,6 +39,7 @@ import java.util.logging.Level;
  */
 final class LoggedTest {
 
+  @SuppressWarnings("JTCOP.RuleAssertionMessage")
   @Test
   void writesXmlLog() throws Exception {
     final Level lvl = Level.INFO;


### PR DESCRIPTION
closes #44 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `jtcop` version and suppresses a warning in `LoggedTest`.

### Detailed summary
- Updated `jtcop` version from `0.1.14` to `0.1.16` in `pom.xml`.
- Suppressed a `JTCOP.RuleAssertionMessage` warning in `LoggedTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->